### PR TITLE
Fix CSS README typos

### DIFF
--- a/assets/css/_README.md
+++ b/assets/css/_README.md
@@ -85,9 +85,9 @@ Only the `<section>` element may scroll, unless explicitly justified. All ancest
 
 ## Todo
 
-- add item JS/data logiic
-- delete item JS/data logiic
-- edit item JS/data logiic
+- add item JS/data logic
+- delete item JS/data logic
+- edit item JS/data logic
 
 ## Single Page Application (SPA)
 


### PR DESCRIPTION
## Summary
- fix three typo instances of "logiic" in CSS README

## Testing
- `grep -n logiic -R assets/css`