### PR TITLE
Fix reset button toggling

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -11,7 +11,7 @@ const fieldset = form.querySelector('fieldset'); // Form field grouping
 const newButton = document.querySelector('button'); // New row button
 const resetButton = form.querySelector('[data-reset]'); // Reset button reference
 
-form.oninput = () => toggleResetButton(); // Reserved for future extension (placeholder)
+form.oninput = toggleResetButton; // run after any input event
 
 // === Utility: Format ISO Date to input[type="datetime-local"] value ===
 function formatDateForInput(str) {
@@ -166,6 +166,7 @@ function updateFormFromSelectedRow() {
   });
 
   snapshotForm();
+  toggleResetButton();
 }
 
 
@@ -178,8 +179,11 @@ function snapshotForm() {
   // Explicitly set initial button state correctly after snapshot
   const submitBtn = form.querySelector('button[type="submit"]');
   submitBtn.disabled = !form.checkValidity(); // crucial fix
+}
 
-  toggleResetButton();
+
+function restoreForm() {
+  updateFormFromSelectedRow();
 }
 
 
@@ -190,7 +194,13 @@ function hasUnsavedChanges() {
 }
 
 function toggleResetButton() {
-  resetButton.disabled = !hasUnsavedChanges();
+  const dirty = hasUnsavedChanges();
+  resetButton.disabled = !dirty;
+  if (dirty) {
+    form.setAttribute('data-dirty', '');
+  } else {
+    form.removeAttribute('data-dirty');
+  }
 }
 window.onbeforeunload = () => hasUnsavedChanges() ? true : undefined;
 
@@ -274,10 +284,10 @@ form.onsubmit = e => {
 // === Form Reset ===
 form.onreset = () => {
   if (!confirm('Reset all changes?')) return;
-  updateFormFromSelectedRow();
+  restoreForm();
+  toggleResetButton();
   const submitBtn = form.querySelector('button[type="submit"]');
   submitBtn.disabled = true;
-  toggleResetButton();
 };
 
 


### PR DESCRIPTION
## Summary
- clean up toggleResetButton usage
- keep toggleResetButton external to snapshotForm and restoreForm
- ensure reset button state updates when rows load, form resets, or new rows are created

## Testing
- `node -v`
