### PR TITLE
Fix custom tag name generation

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -44,13 +44,19 @@ function toKebab(str) {
     .toLowerCase();
 
   if (!dashed.includes("-")) {
-    dashed = dashed.replace(
-      /(name|type|id|date|time|url|ip|count|size|set|list|item)$/,
-      "-$1",
-    );
+    if (/^(name|type|id|date|time|url|ip|count|size|set|list|item)$/.test(dashed)) {
+      dashed = `${dashed}-`;
+    } else {
+      dashed = dashed.replace(
+        /(name|type|id|date|time|url|ip|count|size|set|list|item)$/,
+        "-$1",
+      );
+    }
   }
 
   if (!dashed.includes("-")) dashed = `${dashed}-`;
+
+  if (dashed.startsWith("-")) dashed = `${dashed.slice(1)}-`;
 
   return dashed;
 }


### PR DESCRIPTION
## Summary
- prevent leading dashes when converting JSON keys to tag names

## Testing
- `npm test` *(fails: missing `package.json`)*