### PR TITLE
Fix duplicate unload handler

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -187,7 +187,6 @@ function hasUnsavedChanges() {
     fieldset.querySelectorAll("input[name], select[name]")
   ).some((el) => el.value !== originalData[el.name])
 }
-window.onbeforeunload = () => (hasUnsavedChanges() ? true : undefined)
 
 // Modal & UI Utilities
 function showModal({ title = "", message = "", buttons = [] }) {
@@ -679,8 +678,7 @@ closeButton.onclick = () => {
     clearFieldset(fieldset) // <-- Call your new utility clearly
     form.oninput()
 
-    const mainEl = document.querySelector("main")
-    if (mainEl) removeInlineStyles(mainEl)
+    removeInlineStyles(mainEl)
 
     snapshotForm()
   }


### PR DESCRIPTION
## Summary
- clean up scripts.js
- remove duplicate `onbeforeunload` handler
- reuse global `mainEl` for closing aside

## Testing
- `node --check assets/js/scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_683ae206e344832b90c4dcdf0597ed36