### PR TITLE
Refactor fetch logic and inline confirmations

### DIFF
--- a/assets/js/utils/fetchJSON.js
+++ b/assets/js/utils/fetchJSON.js
@@ -1,0 +1,14 @@
+export const BASE_URL = 'https://67d944ca00348dd3e2aa65f4.mockapi.io/';
+
+export async function fetchJSON(endpoint = '') {
+	try {
+		const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
+		const res = await fetch(url);
+		const text = await res.text();
+		const data = JSON.parse(text);
+		return data;
+	} catch (err) {
+		console.error('Invalid JSON:', err);
+		return { error: err.message };
+	}
+}


### PR DESCRIPTION
## Summary
- move JSON fetch logic to `utils/fetchJSON.js`
- import shared `fetchJSON` utility
- remove alert/confirm modals and show inline errors
- reuse buttons as confirmation dialogs via `aria-label` changes

## Testing
- `npx prettier --write assets/js/scripts.js assets/js/utils/fetchJSON.js`
- `node --check assets/js/scripts.js`
- `node --check assets/js/utils/fetchJSON.js`


------
https://chatgpt.com/codex/tasks/task_e_68538fe590f8832b8372e52f2b8db943