### PR TITLE
Update fetchJSON and improve form confirmations

### DIFF
--- a/assets/css/forms.css
+++ b/assets/css/forms.css
@@ -1,230 +1,233 @@
 :root {
-  --input-border-color: 255, 255, 255;
-  --input-bg-color: 0, 0, 0;
-  --button-bg-color: 102, 204, 255;
-  --valid-border-color: var(--valid-border-color);
-  --invalid-border-color: var(--invalid-border-color);
-  --invalid-placeholder-color: var(--invalid-placeholder-color);
-  --error-color: var(--error-color);
-  --after-color: var(--after-color);
+	--input-border-color: 255, 255, 255;
+	--input-bg-color: 0, 0, 0;
+	--button-bg-color: 102, 204, 255;
+	--valid-border-color: var(--valid-border-color);
+	--invalid-border-color: var(--invalid-border-color);
+	--invalid-placeholder-color: var(--invalid-placeholder-color);
+	--error-color: var(--error-color);
+	--after-color: var(--after-color);
 }
 
 article {
-  select {
-    border-color: rgba(var(--input-border-color), 0.1);
-    width: fit-content;
-    padding: .5rem 1rem;
-    border-radius: var(--border-radius);
-    background-color: rgba(var(--input-bg-color), 0.1);
-    justify-self: end;
-  }
+	select {
+		border-color: rgba(var(--input-border-color), 0.1);
+		width: fit-content;
+		padding: 0.5rem 1rem;
+		border-radius: var(--border-radius);
+		background-color: rgba(var(--input-bg-color), 0.1);
+		justify-self: end;
+	}
 }
 
 /* MARK: FORMS */
 aside {
-  form {
-    display: grid;
-    max-width: 45rem;
-    overflow: hidden;
-    position: relative;
+	form {
+		display: grid;
+		max-width: 45rem;
+		overflow: hidden;
+		position: relative;
 
-    label {
-      display: grid;
-      gap: 0.5rem;
-    }
+		label {
+			display: grid;
+			gap: 0.5rem;
+		}
 
-    input:invalid:not(:placeholder-shown)::placeholder {
-      color: crimson;
-      font-style: italic;
-    }
+		input:invalid:not(:placeholder-shown)::placeholder {
+			color: crimson;
+			font-style: italic;
+		}
 
-    input,
-    select {
-      padding: 0.5rem;
-      border-radius: var(--border-radius);
-      width: 100%;
-      border: 0.125rem solid rgba(var(--input-border-color), 0.1);
-      background-color: rgba(var(--input-bg-color), 0.1);
-      font-size: 1rem;
-      font-family: inherit;
-      font-size: 100%;
-    }
+		input,
+		select {
+			padding: 0.5rem;
+			border-radius: var(--border-radius);
+			width: 100%;
+			border: 0.125rem solid rgba(var(--input-border-color), 0.1);
+			background-color: rgba(var(--input-bg-color), 0.1);
+			font-size: 1rem;
+			font-family: inherit;
+			font-size: 100%;
+		}
 
-    input:valid,
-    select:valid {
-      border: solid 0.125rem transparent;
-      border-inline-start-color: limegreen;
-    }
+		input:valid,
+		select:valid {
+			border: solid 0.125rem transparent;
+			border-inline-start-color: limegreen;
+		}
 
-    input:invalid,
-    select:invalid {
-      border: solid 0.25rem transparent;
-      border-inline-start-color: red;
-    }
+		input:invalid,
+		select:invalid {
+			border: solid 0.25rem transparent;
+			border-inline-start-color: red;
+		}
 
-    /* https://codepen.io/una/pen/MWMmYxb?editors=1100 */
-    select {
-      appearance: base-select;
-      border: solid 0.0625rem rgba(var(--input-border-color), 0.1);
-      border-radius: var(--border-radius);
-      display: grid;
-      font-family: inherit;
-      font-size: 100%;
+		/* https://codepen.io/una/pen/MWMmYxb?editors=1100 */
+		select {
+			appearance: base-select;
+			border: solid 0.0625rem rgba(var(--input-border-color), 0.1);
+			border-radius: var(--border-radius);
+			display: grid;
+			font-family: inherit;
+			font-size: 100%;
 
-      option {
-        font-family: inherit;
-        font-size: 100%;
+			option {
+				font-family: inherit;
+				font-size: 100%;
 
-        &::checkmark {
-          display: none;
-        }
-      }
+				&::checkmark {
+					display: none;
+				}
+			}
 
-      &::picker-icon {
-        display: none;
-      }
-    }
+			&::picker-icon {
+				display: none;
+			}
+		}
 
-    ::picker(select) {
-      appearance: base-select;
-    }
+		::picker(select) {
+			appearance: base-select;
+		}
 
-    input:invalid:not(:placeholder-shown)::placeholder {
-      color: crimson;
-      font-style: italic;
-    }
+		input:invalid:not(:placeholder-shown)::placeholder {
+			color: crimson;
+			font-style: italic;
+		}
 
-    button {
-      background-color: rgba(var(--button-bg-color), 0.25);
-    }
+		button {
+			background-color: rgba(var(--button-bg-color), 0.25);
+		}
 
-    button:disabled {
-      background-color: rgba(var(--button-bg-color), 0.1);
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
+		button:disabled {
+			background-color: rgba(var(--button-bg-color), 0.1);
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
 
-    button:hover,
-    button:focus-visible {
-      background-color: rgba(var(--button-bg-color), 0.5);
-      color: rgba(var(--txt-active));
-    }
+		button:hover,
+		button:focus-visible {
+			background-color: rgba(var(--button-bg-color), 0.5);
+			color: rgba(var(--txt-active));
+		}
 
-    &:has([data-dirty="true"]):valid::after {
-      content: '✓ Ready to submit';
-      display: block;
-      color: var(--after-color);
-      margin-top: 0.5rem;
-      animation: fadeIn 0.5s ease-in-out;
-    }
+		&:has([data-dirty='true']):valid::after {
+			content: '✓ Ready to submit';
+			display: block;
+			color: var(--after-color);
+			margin-top: 0.5rem;
+			animation: fadeIn 0.5s ease-in-out;
+		}
 
-    &:has(:invalid) button[type="submit"] {
-      pointer-events: none;
-      opacity: 0.5;
-    }
+		&:has(:invalid) button[type='submit'] {
+			pointer-events: none;
+			opacity: 0.5;
+		}
 
-    .error {
-      color: red;
-      font-size: 0.85rem;
-      display: none;
-    }
+		.error {
+			color: red;
+			font-size: 0.85rem;
+			display: none;
+		}
 
-    input:invalid:not(:placeholder-shown) + .error {
-      display: block;
-    }
-  }
+		input:invalid:not(:placeholder-shown) + .error {
+			display: block;
+		}
+	}
 }
 
 /* aside form:has(input:not(:placeholder-shown)) {
   display: grid;
 } */
 
-
-
-
 aside form select option::checkmark,
 aside form select::picker-icon {
-  display: none;
+	display: none;
 }
 
 aside form select ::picker(select) {
-  border-radius: var(--border-radius);
-  padding: 0;
-  box-shadow: 0 12.8px 28.8px rgba(0, 0, 0, 0.13), 0 0 9.2px rgba(0, 0, 0, 0.11);
-  border: 1px solid #ececec;
+	border-radius: var(--border-radius);
+	padding: 0;
+	box-shadow:
+		0 12.8px 28.8px rgba(0, 0, 0, 0.13),
+		0 0 9.2px rgba(0, 0, 0, 0.11);
+	border: 1px solid #ececec;
 }
 
 aside form select option {
-  grid-template-columns: 1.5rem 1fr auto;
-  padding: 0.5rem 1rem;
-  place-items: start;
+	grid-template-columns: 1.5rem 1fr auto;
+	padding: 0.5rem 1rem;
+	place-items: start;
 }
 
 aside form select option,
 aside form selectedcontent {
-  display: grid;
-  gap: 1rem;
-  font-size: 1rem;
-  align-items: center;
+	display: grid;
+	gap: 1rem;
+	font-size: 1rem;
+	align-items: center;
 }
 
 aside form selectedcontent {
-  padding: 0.5rem;
-  grid-template-columns: 1.5rem auto;
+	padding: 0.5rem;
+	grid-template-columns: 1.5rem auto;
 }
 
 /* MARK: FIELDSETS */
 aside form fieldset {
-  display: grid;
-  overflow: auto;
-  border: none;
-  margin: 0;
-  padding: 0;
+	display: grid;
+	overflow: auto;
+	border: none;
+	margin: 0;
+	padding: 0;
 }
 
 aside form legend {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0 0 0 0);
+	white-space: nowrap;
+	border: 0;
 }
 
 aside form fieldset label {
-  display: block;
-  font-size: 0.875rem;
-  font-weight: 500;
-  text-transform: capitalize;
-  margin-block-end: 0.25rem;
-  margin-block-start: 1rem;
-  margin-inline: 1rem;
+	display: block;
+	font-size: 0.875rem;
+	font-weight: 500;
+	text-transform: capitalize;
+	margin-block-end: 0.25rem;
+	margin-block-start: 1rem;
+	margin-inline: 1rem;
 }
 
-aside form input[type="checkbox"] {
-  margin-right: 0.5rem;
-  vertical-align: middle;
+aside form input[type='checkbox'] {
+	margin-right: 0.5rem;
+	vertical-align: middle;
 }
 
 /* MARK: CONFIRMATION
 */
 aside form > p {
-  display: none;
-  font-weight: bold;
-  margin-block-end: 0.5rem;
+	display: none;
+	font-weight: bold;
+	margin-block-end: 0.5rem;
 }
 
-aside form > p:has(+ button[aria-label="confirm-save"]),
-aside form > p:has(+ button[aria-label="confirm-delete"]),
-aside form > p:has(+ button[aria-label="confirm-reset"]),
-aside form > p:has(+ button[aria-label="confirm-close"]) {
-  display: block;
+aside form > p:has(+ button[aria-label='confirm-save']),
+aside form > p:has(+ button[aria-label='saved']),
+aside form > p:has(+ button[aria-label='confirm-delete']),
+aside form > p:has(+ button[aria-label='confirm-reset']) {
+	display: block;
+}
+
+aside > p:has(+ button[aria-label='confirm-close']) {
+	display: block;
 }
 
 /* https://x.com/argyleink/status/1927220175385866387 */
 textarea {
-  scrollbar-width: thin;
+	scrollbar-width: thin;
 }

--- a/assets/js/utils/fetchJSON.js
+++ b/assets/js/utils/fetchJSON.js
@@ -5,10 +5,10 @@ export async function fetchJSON(endpoint = '') {
 		const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
 		const res = await fetch(url);
 		const text = await res.text();
-		const data = JSON.parse(text);
-		return data;
+		JSON.parse(text); // validate JSON
+		return text;
 	} catch (err) {
 		console.error('Invalid JSON:', err);
-		return { error: err.message };
+		return `Error: ${err.message}`;
 	}
 }

--- a/index.html
+++ b/index.html
@@ -1,107 +1,114 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-us">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="author" content="D7460N" />
+		<meta name="description" content="DHCP Portal" />
+		<meta name="robots" content="index, archive" />
+		<meta name="color-scheme" content="dark light" />
+		<!-- <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials"> -->
+		<link rel="canonical" href="https://d7460n.dev/" />
+		<link rel="icon" type="image/svg+xml" href="./assets/images/brand/logos/logo.svg" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/themes.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/layout.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/reset.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/loading.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/scrollbars.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/transitions.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/typography.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/responsive.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/a11y.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/forms.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/fonts.css" />
+		<title>DHCP Portal</title>
+	</head>
 
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="D7460N">
-    <meta name="description" content="DHCP Portal">
-    <meta name="robots" content="index, archive">
-    <meta name="color-scheme" content="dark light">
-    <!-- <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials"> -->
-    <link rel="canonical" href="https://d7460n.dev/">
-    <link rel="icon" type="image/svg+xml" href="./assets/images/brand/logos/logo.svg">
-    <link rel="stylesheet" type="text/css" href="./assets/css/themes.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/layout.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/reset.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/loading.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/scrollbars.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/transitions.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/typography.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/responsive.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/a11y.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/forms.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/fonts.css">
-    <title>DHCP Portal</title>
-  </head>
+	<body>
+		<app-container>
+			<app-banner>
+				<p>banner</p>
+			</app-banner>
+			<header>
+				<app-logo>
+					<a href="/" aria-label="Go to D7460N Architecture Home">D7460N Architecture</a>
+				</app-logo>
+				<label>
+					Layouts
+					<input type="checkbox" checked />
+				</label>
+				<label>
+					&#9788;
+					<input type="checkbox" />
+				</label>
+			</header>
+			<nav>
+				<!-- <h4>Filters</h4> -->
+				<details open>
+					<summary>SCOPE</summary>
+					<section></section>
+				</details>
+				<details open>
+					<summary>ADMIN</summary>
+					<section></section>
+				</details>
+			</nav>
+			<main>
+				<article>
+					<h1></h1>
+					<p></p>
+					<button type="button" aria-label="Add new item">
+						New Item
+						<svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+							<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
+							<path
+								d="M12 8v8m-4-4h8"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</button>
+					<hr />
+					<input type="search" placeholder="Filter by name..." name="filter" />
+					<ul aria-hidden="true">
+						<li></li>
+					</ul>
+					<ul></ul>
+				</article>
+			</main>
+			<aside>
+				<h2 aria-live="polite">DETAILS</h2>
+				<button aria-label="Close">&#10006;</button>
+				<p>Click again to confirm closing.</p>
+				<form>
+					<fieldset></fieldset>
+					<small>Note: Ensure all fields are filled correctly before submitting.</small>
+					<small>Note: All fields marked with * are required.</small>
+					<p>Click again to confirm deletion.</p>
+					<button name="delete" type="button" aria-label="Delete">Delete</button>
+					<p>Click again to confirm reset.</p>
+					<button name="reset" type="reset" aria-label="Reset" disabled>Reset</button>
+					<p>Click again to confirm saving.</p>
+					<button name="submit" type="submit" aria-label="Save" disabled>Save</button>
+					<p></p>
+				</form>
+			</aside>
+			<footer>
+				<powered-by
+					>Powered by : :
+					<a href="https://github.com/D7460N/" target="_blank" rel="noopener">D7460N</a></powered-by
+				>
+				<app-version>v.0.00001</app-version>
+			</footer>
+			<app-banner>
+				<p>banner</p>
+			</app-banner>
+		</app-container>
 
-  <body>
-    <app-container>
-      <app-banner>
-        <p>banner</p>
-      </app-banner>
-      <header>
-        <app-logo>
-          <a href="/" aria-label="Go to D7460N Architecture Home">D7460N Architecture</a>
-        </app-logo>
-        <label>
-          Layouts
-          <input type="checkbox" checked />
-        </label>
-        <label>
-          &#9788;
-          <input type="checkbox" />
-        </label>
-      </header>
-      <nav>
-        <!-- <h4>Filters</h4> -->
-        <details open>
-          <summary>SCOPE</summary>
-          <section></section>
-        </details>
-        <details open>
-          <summary>ADMIN</summary>
-          <section></section>
-        </details>
-      </nav>
-      <main>
-        <article>
-          <h1></h1>
-          <p></p>
-          <button type="button" aria-label="Add new item">
-            New Item
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
-              <path d="M12 8v8m-4-4h8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-            </svg>
-          </button>
-          <hr />
-          <input type="search" placeholder="Filter by name..." name="filter" />
-          <ul aria-hidden="true">
-            <li></li>
-          </ul>
-          <ul></ul>
-        </article>
-      </main>
-      <aside>
-        <h2 aria-live="polite">DETAILS</h2>
-        <button aria-label="Close">&#10006;</button>
-        <form>
-          <fieldset></fieldset>
-          <small>Note: Ensure all fields are filled correctly before
-            submitting.</small>
-          <small>Note: All fields marked with * are required.</small>
-          <p>Click again to confirm saving.</p>
-          <p>Click again to confirm deletion.</p>
-          <p>Click again to confirm reset.</p>
-          <p>Click again to confirm closing.</p>
-          <button name="delete" type="button" aria-label="Delete">Delete</button>
-          <button name="reset" type="reset" aria-label="Reset" disabled>Reset</button>
-          <button name="submit" type="submit" aria-label="Save" disabled>Save</button>
-        </form>
-      </aside>
-      <footer>
-        <powered-by>Powered by : : <a href="https://github.com/D7460N/" target="_blank" rel="noopener">D7460N</a></powered-by>
-        <app-version>v.0.00001</app-version>
-      </footer>
-      <app-banner>
-        <p>banner</p>
-      </app-banner>
-    </app-container>
-
-    <script type="module" src="./assets/js/scripts.js"></script>
-    <!-- <script>
+		<script type="module" src="./assets/js/scripts.js"></script>
+		<!-- <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('./sw.js')
           .then(() => navigator.serviceWorker.ready)
@@ -109,6 +116,5 @@
           .catch(err => console.error('SW registration failed:', err))
       }
     </script> -->
-  </body>
-
+	</body>
 </html>


### PR DESCRIPTION
## Summary
- validate JSON and return text in fetch utility
- parse JSON in scripts before using data
- reorder inline messages and expose save confirmation feedback
- reveal confirm prompts for close button and page blur

## Testing
- `npx --yes prettier -w index.html assets/js/utils/fetchJSON.js assets/js/scripts.js assets/css/forms.css`

------
https://chatgpt.com/codex/tasks/task_e_68541cb7e68c832b931e8b3121bf1ea6