### PR TITLE
Separate API config for reuse

### DIFF
--- a/assets/js/README.md
+++ b/assets/js/README.md
@@ -250,3 +250,13 @@ Example template:
 | Tab content load                | Nav input click     | `/manage`, `/faqs`, `/api-registration`, etc. |
 | Save Form (`POST` or `PUT`)     | Form submit         | `/endpoint` or `/endpoint/:id`                |
 | Delete Row (`DELETE`)           | Delete button click | `/endpoint/:id`                               |
+
+## Configuration Module
+
+`config.js` defines deployment settings such as the API base URL and optional feature flags.
+Override this file to customize the host or toggle behaviors when using the scripts in other projects.
+
+```javascript
+export const BASE_URL = 'https://67d944ca00348dd3e2aa65f4.mockapi.io/';
+export const OPTIONS = { showBanner: true, warnOnBlur: true };
+```

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,0 +1,6 @@
+export const BASE_URL = 'https://67d944ca00348dd3e2aa65f4.mockapi.io/';
+
+export const OPTIONS = {
+	showBanner: true,
+	warnOnBlur: true,
+};

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,7 +1,8 @@
 // MARK: SCRIPTS.JS
 
+import { BASE_URL, OPTIONS } from './config.js';
+
 // Shared fetch utility for all data calls
-const BASE_URL = 'https://67d944ca00348dd3e2aa65f4.mockapi.io/';
 
 async function fetchJSON(endpoint = '') {
 	try {
@@ -299,7 +300,7 @@ async function loadAppBanner() {
 	}
 }
 
-loadAppBanner();
+if (OPTIONS.showBanner) loadAppBanner();
 
 // Form State Utilities
 // MARK: TRACK FROM ORIGINAL STATE
@@ -350,7 +351,6 @@ function restoreForm() {
 	}
 }
 
-
 // Toggle the disabled state of the Reset button based on form changes
 function toggleResetItem() {
 	// Guard clause: ensure the reset button exists before proceeding
@@ -377,7 +377,6 @@ function toggleResetItem() {
 	} else {
 		status.hidden = true;
 	}
-
 }
 
 // Toggle the disabled state of the Submit button based on form validity and changes
@@ -406,7 +405,6 @@ function toggleSubmitItem() {
 	} else {
 		status.hidden = true;
 	}
-
 }
 
 // Confirmation logic utility: guards critical actions based on dirty state
@@ -747,7 +745,6 @@ loadNavItems().then(() => {
 newItem.onclick = async () => {
 	// First, check if there are unsaved form changes
 	unsavedCheck(confirmFlags.save, hasUnsavedChanges, () => {
-
 		// Clear the form's current input fields to prepare for creating a new entry
 		fieldset.innerHTML = '';
 
@@ -831,7 +828,6 @@ newItem.onclick = async () => {
 
 		// Update the reset button state (enabled or disabled) based on current form data state
 		toggleResetItem();
-
 	});
 };
 
@@ -842,7 +838,6 @@ form.onsubmit = async e => {
 	e.preventDefault();
 
 	unsavedCheck(confirmFlags.save, hasUnsavedChanges, async () => {
-
 		const selected = document.querySelector('ul li input[name="list-item"]:checked');
 		const id = selected?.closest('li')?.querySelector('label > id')?.textContent?.trim();
 		const endpoint = document.querySelector('nav input[name="nav"]:checked')?.value;
@@ -876,10 +871,8 @@ form.onsubmit = async e => {
 			const intro = document.querySelector('main article > p');
 			if (intro) intro.textContent = '⚠️ Error saving record.';
 		}
-
 	});
 };
-
 
 // MARK: FORM RESET
 
@@ -892,7 +885,6 @@ form.onreset = e => {
 		snapshotForm();
 	});
 };
-
 
 // MARK: DELETE HANDLER
 
@@ -928,12 +920,13 @@ deleteItem.onclick = () => {
 	});
 };
 
-
 // MARK: CLOSE ASIDE
 if (closeItem) {
 	closeItem.onclick = () => {
 		unsavedCheck(confirmFlags.close, hasUnsavedChanges, () => {
-			const selected = document.querySelector('ul li input[name="list-item"]:checked')?.closest('li');
+			const selected = document
+				.querySelector('ul li input[name="list-item"]:checked')
+				?.closest('li');
 			if (selected) {
 				const radio = selected.querySelector('input[name="list-item"]');
 				if (radio) radio.checked = false;
@@ -948,12 +941,12 @@ if (closeItem) {
 	};
 }
 
-
-
 // Prompt user to save or delete when page loses focus if there are unsaved changes
-window.onblur = () => {
-	if (hasUnsavedChanges()) {
-		confirmFlags.save.value = true;
-		confirmFlags.delete.value = true;
-	}
-};
+if (OPTIONS.warnOnBlur) {
+	window.onblur = () => {
+		if (hasUnsavedChanges()) {
+			confirmFlags.save.value = true;
+			confirmFlags.delete.value = true;
+		}
+	};
+}

--- a/index.html
+++ b/index.html
@@ -1,108 +1,115 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en-us">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="author" content="D7460N" />
+		<meta name="description" content="DHCP Portal" />
+		<meta name="robots" content="index, archive" />
+		<meta name="color-scheme" content="dark light" />
+		<!-- <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials"> -->
+		<link rel="canonical" href="https://d7460n.dev/" />
+		<link rel="icon" type="image/svg+xml" href="./assets/images/brand/logos/logo.svg" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/themes.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/layout.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/reset.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/loading.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/scrollbars.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/transitions.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/typography.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/responsive.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/a11y.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/forms.css" />
+		<link rel="stylesheet" type="text/css" href="./assets/css/fonts.css" />
+		<title>DHCP Portal</title>
+	</head>
 
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="author" content="D7460N">
-    <meta name="description" content="DHCP Portal">
-    <meta name="robots" content="index, archive">
-    <meta name="color-scheme" content="dark light">
-    <!-- <link rel="manifest" href="manifest.webmanifest" crossorigin="use-credentials"> -->
-    <link rel="canonical" href="https://d7460n.dev/">
-    <link rel="icon" type="image/svg+xml" href="./assets/images/brand/logos/logo.svg">
-    <link rel="stylesheet" type="text/css" href="./assets/css/themes.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/layout.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/reset.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/loading.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/scrollbars.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/transitions.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/typography.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/responsive.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/a11y.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/forms.css">
-    <link rel="stylesheet" type="text/css" href="./assets/css/fonts.css">
-    <title>DHCP Portal</title>
-  </head>
+	<body>
+		<app-container>
+			<app-banner>
+				<p>This is default banner text, not from a server.</p>
+			</app-banner>
+			<header>
+				<app-logo>
+					<a href="/" aria-label="Go to D7460N Architecture Home">D7460N Architecture</a>
+				</app-logo>
+				<label>
+					Layouts
+					<input type="checkbox" checked />
+				</label>
+				<label>
+					&#9788;
+					<input type="checkbox" />
+				</label>
+			</header>
+			<nav>
+				<!-- <h4>Filters</h4> -->
+				<details open>
+					<summary></summary>
+					<section></section>
+				</details>
+				<details open>
+					<summary></summary>
+					<section></section>
+				</details>
+			</nav>
+			<main>
+				<article>
+					<h1></h1>
+					<p></p>
+					<label role="button" aria-label="Add new item">
+						<input type="checkbox" />
+						New Item
+						<svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+							<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
+							<path
+								d="M12 8v8m-4-4h8"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</label>
+					<hr />
+					<input type="search" placeholder="Filter by name..." name="filter" />
+					<ul aria-hidden="true">
+						<li></li>
+					</ul>
+					<ul></ul>
+				</article>
+			</main>
+			<aside>
+				<h2 aria-live="polite">DETAILS</h2>
+				<label role="button" aria-label="Close">
+					<input type="checkbox" />
+					&#10006;
+				</label>
+				<form>
+					<fieldset></fieldset>
+					<p aria-live="polite"></p>
+					<small>Note: Ensure all fields are filled correctly before submitting.</small>
+					<small>Note: All fields marked with * are required.</small>
+					<button name="delete" type="button" aria-label="Delete">Delete</button>
+					<button name="reset" type="reset" aria-label="Reset" disabled>Reset</button>
+					<button name="submit" type="submit" aria-label="Save" disabled>Save</button>
+				</form>
+			</aside>
+			<footer>
+				<powered-by
+					>Powered by : :
+					<a href="https://github.com/D7460N/" target="_blank" rel="noopener">D7460N</a></powered-by
+				>
+				<app-version>v.0.00001</app-version>
+			</footer>
+			<app-banner>
+				<p>This is default banner text, not from a server.</p>
+			</app-banner>
+		</app-container>
 
-  <body>
-    <app-container>
-      <app-banner>
-        <p>This is default banner text, not from a server.</p>
-      </app-banner>
-      <header>
-        <app-logo>
-          <a href="/" aria-label="Go to D7460N Architecture Home">D7460N Architecture</a>
-        </app-logo>
-        <label>
-          Layouts
-          <input type="checkbox" checked />
-        </label>
-        <label>
-          &#9788;
-          <input type="checkbox" />
-        </label>
-      </header>
-      <nav>
-        <!-- <h4>Filters</h4> -->
-        <details open>
-          <summary></summary>
-          <section></section>
-        </details>
-        <details open>
-          <summary></summary>
-          <section></section>
-        </details>
-      </nav>
-      <main>
-        <article>
-          <h1></h1>
-          <p></p>
-          <label role="button" aria-label="Add new item">
-            <input type="checkbox">
-            New Item
-            <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
-              <path d="M12 8v8m-4-4h8" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-            </svg>
-          </label>
-          <hr />
-          <input type="search" placeholder="Filter by name..." name="filter" />
-          <ul aria-hidden="true">
-            <li></li>
-          </ul>
-          <ul></ul>
-        </article>
-      </main>
-      <aside>
-        <h2 aria-live="polite">DETAILS</h2>
-        <label role="button" aria-label="Close">
-          <input type="checkbox">
-          &#10006;
-        </label>
-        <form>
-          <fieldset></fieldset>
-          <p aria-live="polite"></p>
-          <small>Note: Ensure all fields are filled correctly before
-            submitting.</small>
-          <small>Note: All fields marked with * are required.</small>
-          <button name="delete" type="button" aria-label="Delete">Delete</button>
-          <button name="reset" type="reset" aria-label="Reset" disabled>Reset</button>
-          <button name="submit" type="submit" aria-label="Save" disabled>Save</button>
-        </form>
-      </aside>
-      <footer>
-        <powered-by>Powered by : : <a href="https://github.com/D7460N/" target="_blank" rel="noopener">D7460N</a></powered-by>
-        <app-version>v.0.00001</app-version>
-      </footer>
-      <app-banner>
-        <p>This is default banner text, not from a server.</p>
-      </app-banner>
-    </app-container>
-
-    <script type="module" src="./assets/js/scripts.js"></script>
-    <!-- <script>
+		<script type="module" src="./assets/js/config.js"></script>
+		<script type="module" src="./assets/js/scripts.js"></script>
+		<!-- <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('./sw.js')
           .then(() => navigator.serviceWorker.ready)
@@ -110,6 +117,5 @@
           .catch(err => console.error('SW registration failed:', err))
       }
     </script> -->
-  </body>
-
+	</body>
 </html>


### PR DESCRIPTION
## Summary
- introduce `config.js` for customizable base URL and feature flags
- reference new config in scripts
- conditionally load banner and blur warnings
- load config module in index.html
- document configuration module

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685826ea81c8832b8e2f6f327d3f347c