### PR TITLE
Refactor fetch utilities

### DIFF
--- a/assets/js/fetch.js
+++ b/assets/js/fetch.js
@@ -1,0 +1,44 @@
+import { BASE_URL, JSON_HEADERS as HEADERS } from './config.js';
+
+function toUrl(endpoint = '') {
+	return endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
+}
+
+async function handle(res) {
+	if (!res.ok) throw new Error(`STATUS ${res.status}`);
+	const text = await res.text();
+	JSON.parse(text);
+	return text;
+}
+
+export async function fetchJSON(endpoint = '') {
+	const res = await fetch(toUrl(endpoint));
+	return handle(res);
+}
+
+export async function postJSON(endpoint = '', data = {}) {
+	const res = await fetch(toUrl(endpoint), {
+		method: 'POST',
+		headers: HEADERS,
+		body: JSON.stringify(data),
+	});
+	return handle(res);
+}
+
+export async function putJSON(endpoint = '', data = {}) {
+	const res = await fetch(toUrl(endpoint), {
+		method: 'PUT',
+		headers: HEADERS,
+		body: JSON.stringify(data),
+	});
+	return handle(res);
+}
+
+export async function deleteJSON(endpoint = '') {
+	const res = await fetch(toUrl(endpoint), {
+		method: 'DELETE',
+		headers: HEADERS,
+	});
+	if (!res.ok) throw new Error(`STATUS ${res.status}`);
+	return '';
+}


### PR DESCRIPTION
## Summary
- extract data fetch helpers from scripts.js to new `fetch.js`
- use new helpers for form submit and delete handling

## Testing
- `npx prettier -c assets/js/fetch.js assets/js/scripts.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68644b948950832bb75fcb620d1bce4f