### PR TITLE
Module 7: Extract utilities

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,0 +1,23 @@
+export function formatDateForInput(str = '') {
+	const d = new Date(str);
+	return Number.isNaN(d) ? '' : d.toISOString().slice(0, 16);
+}
+
+export function normalizeKey(str = '') {
+	return str
+		.replace(/([a-z])([A-Z])/g, '$1-$2')
+		.replace(/_/g, '-')
+		.toLowerCase();
+}
+
+export function snapshotForm(elements = []) {
+	const data = {};
+	elements.forEach(el => {
+		data[el.name] = el.value;
+	});
+	return data;
+}
+
+export function hasUnsavedChanges(elements = [], original = {}) {
+	return Array.from(elements).some(el => el.value !== original[el.name]);
+}


### PR DESCRIPTION
## Summary
- add `utils.js` with reusable helpers
- refactor `scripts.js` to import helpers

## Testing
- `npx prettier -w assets/js/utils.js assets/js/scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_68647cd8b1fc832bbe874cef244e2e2a