### PR TITLE
refactor(css): move scroll-snap out of transitions.css into scrollbars.css (parked)

### DIFF
--- a/assets/css/scrollbars.css
+++ b/assets/css/scrollbars.css
@@ -20,3 +20,19 @@ aside form fieldset {
 textarea {
   scrollbar-width: thin;
 }
+
+/* MARK: SCROLL-SNAP (parked)
+   Table row-list scroll-snapping. Moved here from transitions.css — it is a
+   scrolling concern, not a transition. Commented out for now: it is part of a
+   larger effort that has not come together yet.
+
+   main article ul:last-of-type {
+     overflow-x: auto;
+     scroll-snap-type: y mandatory;
+
+     > * {
+       grid-template-columns: auto;
+       scroll-snap-align: start;
+     }
+   }
+*/

--- a/assets/css/transitions.css
+++ b/assets/css/transitions.css
@@ -70,16 +70,6 @@ button,
   transition: background-color var(--transition-duration), color var(--transition-duration);
 } */
 
-main article ul:last-of-type {
-  overflow-x: auto;
-  scroll-snap-type: y mandatory;
-
-  > * {
-    grid-template-columns: auto;
-    scroll-snap-align: start;
-  }
-}
-
 /* @keyframes fadeIn {
   from {
     opacity: 0;


### PR DESCRIPTION
Moves the `main article ul:last-of-type` scroll-snap block out of `transitions.css` (it's a scrolling concern, not a transition) into `scrollbars.css`, **commented out**, with a note that it's part of a larger effort not yet assembled.

- `transitions.css` — removes only that block; everything else in the file is byte-unchanged.
- `scrollbars.css` — appends the block as a commented `/* SCROLL-SNAP (parked) … */` note.

DHCP has no `scrolling.css`; `scrollbars.css` is its scroll-concern file (newer repos use `scrolling.css`).

**Heads-up (behavior):** because it's commented out, this **deactivates the data-table row scroll-snap** in the DHCP app for now — intentional per request. No merge; review first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PC3wqYigrVv7SPH5xi3cR7)_