### PR TITLE
refactor(css): remove @view-transition (cross-document only; inert in a SPA)

### DIFF
--- a/assets/css/transitions.css
+++ b/assets/css/transitions.css
@@ -26,30 +26,6 @@
   }
 }
 
-/* https://adactio.com/journal/21896 */
-/*https://webkit.org/blog/7551/responsive-design-for-motion/ */
-@media (prefers-reduced-motion: no-preference) {
-  /* https://webkit.org/blog/16967/two-lines-of-cross-document-view-transitions-code-you-can-use-on-every-website-today/ */
-  @view-transition {
-    navigation: auto;
-  }
-}
-
-/* https://www.bram.us/2025/01/29/view-transitions-page-interactivity/ */
-@layer view-transitions {
-
-  /* Don’t capture the root, allowing pointer interaction while elements are animating */
-  @layer no-root {
-    :root {
-      view-transition-name: none;
-    }
-
-    ::view-transition {
-      pointer-events: none;
-    }
-  }
-}
-
 @starting-style {
   * {
     visibility: hidden;


### PR DESCRIPTION
`@view-transition { navigation: auto }` fires only on same-origin **cross-document navigations** (MDN); this is a single-page app, so it never fires. Removes the `@view-transition` opt-in and the `@layer view-transitions` pointer-events tweak from `transitions.css`. Everything else in the file is unchanged.

**Behavior:** dead code in a SPA → removal is behavior-neutral. Explicitly requested. Can be re-added if the app ever does cross-document navigation.

No merge — review first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PC3wqYigrVv7SPH5xi3cR7)_